### PR TITLE
chore(config): make development configuration portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,14 @@ go.work.sum
 
 # env file
 .env
+.env.*
+!.env.example
+*.local.yaml
+*.local.yml
+*.local.env
+*.pem
+*.p12
+*.pfx
 
 # binary
 bin/
@@ -79,5 +87,6 @@ certs/*.crt
 
 # Local agent and skill configuration
 /.agents/
+/.agent/
 /.playwright-mcp/
 /.mini-wiki/

--- a/deploy-liaison.sh
+++ b/deploy-liaison.sh
@@ -19,18 +19,18 @@
 set -e
 
 # 配置 - Manager
-MANAGER_HOST="49.232.250.11"
-MANAGER_USER="root"
-MANAGER_PORT="22"
+MANAGER_HOST="${MANAGER_HOST:-}"
+MANAGER_USER="${MANAGER_USER:-root}"
+MANAGER_PORT="${MANAGER_PORT:-22}"
 MANAGER_BIN_PATH="/opt/liaison/bin"
 MANAGER_WEB_PATH="/opt/liaison/web"
 MANAGER_SERVICE="liaison"
 MANAGER_BIN="./bin/liaison"
 
 # 配置 - Edge
-EDGE_HOST="49.232.238.228"
-EDGE_USER="root"
-EDGE_PORT="22"
+EDGE_HOST="${EDGE_HOST:-}"
+EDGE_USER="${EDGE_USER:-root}"
+EDGE_PORT="${EDGE_PORT:-22}"
 EDGE_BIN_PATH="/opt/liaison/bin"
 EDGE_SERVICE="liaison-edge"
 EDGE_BIN="./bin/liaison-edge"
@@ -85,6 +85,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --help, -h          显示帮助信息"
             echo ""
             echo "示例:"
+            echo "  MANAGER_HOST=manager.example.com EDGE_HOST=edge.example.com $0"
+            echo "  MANAGER_HOST=manager.example.com $0 --web"
             echo "  $0                  # 部署所有（前端、liaison、edge）"
             echo "  $0 --web            # 仅部署前端"
             echo "  $0 --liaison        # 仅部署 liaison"
@@ -104,6 +106,16 @@ if [ "$DEPLOY_WEB" = false ] && [ "$DEPLOY_LIAISON" = false ] && [ "$DEPLOY_EDGE
     DEPLOY_WEB=true
     DEPLOY_LIAISON=true
     DEPLOY_EDGE=true
+fi
+
+# Require only the hosts needed by the selected deployment, before any build or SSH.
+if { [ "$DEPLOY_WEB" = true ] || [ "$DEPLOY_LIAISON" = true ]; } && [ -z "$MANAGER_HOST" ]; then
+    echo "错误: 请通过 MANAGER_HOST 指定部署目标。" >&2
+    exit 1
+fi
+if [ "$DEPLOY_EDGE" = true ] && [ -z "$EDGE_HOST" ]; then
+    echo "错误: 请通过 EDGE_HOST 指定部署目标。" >&2
+    exit 1
 fi
 
 # 显示部署计划

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,32 @@
+# Local configuration
+
+The checked-in YAML files contain no usable credentials. Do not run them unchanged.
+
+1. Copy `etc/liaison.yaml` to `etc/liaison.local.yaml`, and
+   `etc/liaison-edge.yaml` to `etc/liaison-edge.local.yaml` as needed.
+2. Generate a unique manager JWT secret, for example with `openssl rand -hex 32`,
+   and set `manager.jwt_secret` in the local manager configuration.
+3. Create a connector in your own Liaison installation and place its issued
+   `access_key` and `secret_key` in the local edge configuration.
+4. Set the addresses and TLS configuration for your environment. Start each
+   binary with `-c` pointing to the corresponding local configuration file.
+
+`*.local.yaml` is ignored by Git. Keep these files private and restrict their
+permissions (for example, `chmod 600 etc/*.local.yaml`). Never commit generated
+credentials or copy a secret from an example into a deployed environment.
+
+Packaged installations have their own configuration-generation workflow; these
+development examples do not change the package installer.
+
+## Remote development deployment
+
+The repository-root `deploy-liaison.sh` requires explicit target hosts:
+
+```sh
+MANAGER_HOST=manager.example.com ./deploy-liaison.sh --web
+EDGE_HOST=edge.example.com ./deploy-liaison.sh --edge
+```
+
+For a full deployment, provide both `MANAGER_HOST` and `EDGE_HOST`. SSH users and
+ports can be overridden with `MANAGER_USER`, `MANAGER_PORT`, `EDGE_USER` and
+`EDGE_PORT`. Use your local SSH configuration or agent for authentication.

--- a/etc/liaison-edge.yaml
+++ b/etc/liaison-edge.yaml
@@ -6,8 +6,8 @@ manager:
     tls:
       enable: false
   auth:
-    access_key: "MTc1ODY3NjI3NzIyMTcy"
-    secret_key: "kSwZqzxupTtKB4SmcZ3-oCVWGvbpbfehTVtckTG78q0"
+    access_key: "" # Set in your ignored *.local.yaml configuration.
+    secret_key: "" # Set in your ignored *.local.yaml configuration.
 log:
   level: debug
   file: ./logs/liaison-edge.log

--- a/etc/liaison.yaml
+++ b/etc/liaison.yaml
@@ -5,7 +5,7 @@ manager:
     tls:
       enable: false
   db: /opt/liaison/data/liaison.db
-  jwt_secret: "YJEVmDSDk1FCTzUCJVFsugywxcEUQ4vh"
+  jwt_secret: "" # Set in your ignored *.local.yaml configuration.
   ssh_host_key_file: /opt/liaison/data/ssh_host_ed25519_key
   ssh_idle_timeout: 30m
   ssh_max_duration: 8h

--- a/scripts/test-config-portability.sh
+++ b/scripts/test-config-portability.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+bash -n deploy-liaison.sh
+env -u MANAGER_HOST -u EDGE_HOST bash deploy-liaison.sh --help >/dev/null
+
+expect_missing_host() {
+    local expected="$1"
+    shift
+    local output
+    if output=$(env -u MANAGER_HOST -u EDGE_HOST bash deploy-liaison.sh "$@" 2>&1); then
+        echo "Expected deployment without a target to fail" >&2
+        exit 1
+    fi
+    if [[ "$output" != *"$expected"* ]]; then
+        echo "Expected missing-host validation before build or network access" >&2
+        exit 1
+    fi
+}
+
+expect_missing_host MANAGER_HOST --web
+expect_missing_host MANAGER_HOST --liaison
+expect_missing_host MANAGER_HOST --liaison-only
+expect_missing_host EDGE_HOST --edge
+expect_missing_host MANAGER_HOST
+
+# Development configuration must require locally supplied credentials.
+awk '
+  /^[[:space:]]*(jwt_secret|access_key|secret_key):/ {
+    count++
+    value = $0
+    sub(/^[^:]*:[[:space:]]*/, "", value)
+    sub(/[[:space:]]*#.*/, "", value)
+    if (value != "\"\"") invalid = 1
+  }
+  END { if (count != 3 || invalid) exit 1 }
+' etc/liaison.yaml etc/liaison-edge.yaml
+
+for path in etc/liaison.local.yaml etc/liaison-edge.local.yaml .env.local; do
+    git check-ignore -q "$path"
+done
+
+echo "Configuration portability checks passed"


### PR DESCRIPTION
## Summary
- Require explicit deployment hosts and allow SSH user/port overrides.
- Keep development credentials local and document configuration setup.
- Extend local-file ignore rules and add configuration portability checks.

## Validation
- bash scripts/test-config-portability.sh
- go test ./pkg/liaison/config ./pkg/edge/config (compilation passed; no test files)
- git diff --check

No deployment, runtime credential changes, or Git history rewrite is included.